### PR TITLE
[demo] update sub chart dependencies

### DIFF
--- a/charts/opentelemetry-demo/Chart.lock
+++ b/charts/opentelemetry-demo/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.39.1
+  version: 0.40.2
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 15.16.1
+  version: 17.0.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
-  version: 6.42.2
-digest: sha256:1e865a4eeab047148522d810711c2869038a7eb2300193f50156c5e5aa63f68b
-generated: "2022-11-14T22:16:08.306967-07:00"
+  version: 6.44.8
+digest: sha256:83a1cf5ac2dda07ce8d9bb24f8c0059baec6dc15c3ae62f7fc70e58b004e7942
+generated: "2022-11-25T23:05:16.739586-05:00"

--- a/charts/opentelemetry-demo/Chart.yaml
+++ b/charts/opentelemetry-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: opentelemetry-demo
-version: 0.12.3
+version: 0.12.4
 description: opentelemetry demo helm chart
 home: https://opentelemetry.io/
 sources:
@@ -14,14 +14,14 @@ icon: https://opentelemetry.io/img/logos/opentelemetry-logo-nav.png
 appVersion: "1.1.0"
 dependencies:
   - name: opentelemetry-collector
-    version: 0.39.1
+    version: 0.40.2
     repository: https://open-telemetry.github.io/opentelemetry-helm-charts
     condition: observability.otelcol.enabled
   - name: prometheus
-    version: 15.16.1
+    version: 17.0.2
     repository: https://prometheus-community.github.io/helm-charts
     condition: observability.prometheus.enabled
   - name: grafana
-    version: 6.42.2
+    version: 6.44.8
     repository: https://grafana.github.io/helm-charts
     condition: observability.grafana.enabled

--- a/charts/opentelemetry-demo/examples/default/rendered/component.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/component.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -29,7 +29,7 @@ kind: Service
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -53,7 +53,7 @@ kind: Service
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -77,7 +77,7 @@ kind: Service
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -101,7 +101,7 @@ kind: Service
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -125,7 +125,7 @@ kind: Service
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -152,7 +152,7 @@ kind: Service
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -176,7 +176,7 @@ kind: Service
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -200,7 +200,7 @@ kind: Service
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -224,7 +224,7 @@ kind: Service
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -248,7 +248,7 @@ kind: Service
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -272,7 +272,7 @@ kind: Service
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -296,7 +296,7 @@ kind: Service
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -320,7 +320,7 @@ kind: Service
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -344,7 +344,7 @@ kind: Service
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -368,7 +368,7 @@ kind: Service
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice
@@ -392,7 +392,7 @@ kind: Deployment
 metadata:
   name: example-adservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: adservice
@@ -457,7 +457,7 @@ kind: Deployment
 metadata:
   name: example-cartservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: cartservice
@@ -526,7 +526,7 @@ kind: Deployment
 metadata:
   name: example-checkoutservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: checkoutservice
@@ -603,7 +603,7 @@ kind: Deployment
 metadata:
   name: example-currencyservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: currencyservice
@@ -670,7 +670,7 @@ kind: Deployment
 metadata:
   name: example-emailservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: emailservice
@@ -741,7 +741,7 @@ kind: Deployment
 metadata:
   name: example-featureflagservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: featureflagservice
@@ -814,7 +814,7 @@ kind: Deployment
 metadata:
   name: example-ffspostgres
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: ffspostgres
@@ -883,7 +883,7 @@ kind: Deployment
 metadata:
   name: example-frontend
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontend
@@ -966,7 +966,7 @@ kind: Deployment
 metadata:
   name: example-frontendproxy
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: frontendproxy
@@ -1051,7 +1051,7 @@ kind: Deployment
 metadata:
   name: example-loadgenerator
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: loadgenerator
@@ -1130,7 +1130,7 @@ kind: Deployment
 metadata:
   name: example-paymentservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: paymentservice
@@ -1195,7 +1195,7 @@ kind: Deployment
 metadata:
   name: example-productcatalogservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: productcatalogservice
@@ -1262,7 +1262,7 @@ kind: Deployment
 metadata:
   name: example-quoteservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: quoteservice
@@ -1335,7 +1335,7 @@ kind: Deployment
 metadata:
   name: example-recommendationservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: recommendationservice
@@ -1408,7 +1408,7 @@ kind: Deployment
 metadata:
   name: example-redis
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: redis
@@ -1469,7 +1469,7 @@ kind: Deployment
 metadata:
   name: example-shippingservice
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: shippingservice

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana-dashboards.yaml
@@ -5,7 +5,7 @@ kind: ConfigMap
 metadata:
   name: example-grafana-dashboards
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrole.yaml
@@ -4,10 +4,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-clusterrole
 rules: []

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/clusterrolebinding.yaml
@@ -5,10 +5,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: example-grafana-clusterrolebinding
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/configmap.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 data:
   grafana.ini: |
@@ -34,7 +34,6 @@ data:
     domain = ''
     root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana
     serve_from_sub_path = true
-
   datasources.yaml: |
     apiVersion: 1
     datasources:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/deployment.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -26,11 +26,12 @@ spec:
         app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: example
       annotations:
-        checksum/config: c2e8477af534e32217d99c32fe8186c312aa46a035ba7b97049be0b6f35f9204
+        checksum/config: 8da13757e6a4e26fa5f5d8bea710789604f6f65d9f6c716eebff52d984a872b2
         checksum/dashboards-json-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/sc-dashboard-provider-config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum/secret: fe3e6a98bc5a653cb07ae3c34aadffc8997b5056ca0749f3e7dca826817ca791
-    spec:      
+        checksum/secret: b65090f177ac17645517811495dba2b7c2f5bca558b4947fdc8634daaf65a9d7
+    spec:
+      
       serviceAccountName: example-grafana
       automountServiceAccountToken: true
       securityContext:
@@ -40,7 +41,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.2.0"
+          image: "grafana/grafana:9.2.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config
@@ -94,7 +95,6 @@ spec:
         - name: config
           configMap:
             name: example-grafana
-          
         - name: dashboards-default
           configMap:
             name: example-grafana-dashboards

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/role.yaml
@@ -6,13 +6,13 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:      ['extensions']
-  resources:      ['podsecuritypolicies']
-  verbs:          ['use']
-  resourceNames:  [example-grafana]
+  - apiGroups:      ['extensions']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [example-grafana]

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/rolebinding.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/secret.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/service.yaml
@@ -6,10 +6,10 @@ metadata:
   name: example-grafana
   namespace: default
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-configmap.yaml
@@ -9,10 +9,10 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 data:
   run.sh: |-

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-role.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-role.yaml
@@ -9,13 +9,13 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 rules:
-- apiGroups:      ['policy']
-  resources:      ['podsecuritypolicies']
-  verbs:          ['use']
-  resourceNames:  [example-grafana-test]
+  - apiGroups:      ['policy']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [example-grafana-test]

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-rolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-rolebinding.yaml
@@ -9,16 +9,16 @@ metadata:
     "helm.sh/hook": test-success
     "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: example-grafana-test
 subjects:
-- kind: ServiceAccount
-  name: example-grafana-test
-  namespace: default
+  - kind: ServiceAccount
+    name: example-grafana-test
+    namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test-serviceaccount.yaml
@@ -4,10 +4,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
   name: example-grafana-test
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/grafana/tests/test.yaml
@@ -5,10 +5,10 @@ kind: Pod
 metadata:
   name: example-grafana-test
   labels:
-    helm.sh/chart: grafana-6.42.2
+    helm.sh/chart: grafana-6.44.8
     app.kubernetes.io/name: grafana
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "9.2.0"
+    app.kubernetes.io/version: "9.2.5"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test-success
@@ -26,7 +26,7 @@ spec:
           name: tests
           readOnly: true
   volumes:
-  - name: tests
-    configMap:
-      name: example-grafana-test
+    - name: tests
+      configMap:
+        name: example-grafana-test
   restartPolicy: Never

--- a/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/jaeger.yaml
@@ -5,7 +5,7 @@ kind: Service
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger
@@ -34,7 +34,7 @@ kind: Deployment
 metadata:
   name: example-jaeger
   labels:
-    helm.sh/chart: opentelemetry-demo-0.12.3
+    helm.sh/chart: opentelemetry-demo-0.12.4
     app.kubernetes.io/name: example
     app.kubernetes.io/instance: example
     app.kubernetes.io/component: jaeger

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.1
+    helm.sh/chart: opentelemetry-collector-0.40.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.64.1"
+    app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
 data:
   relay: |
@@ -22,13 +22,14 @@ data:
         endpoint: 0.0.0.0:9464
     extensions:
       health_check: {}
-      memory_ballast: {}
+      memory_ballast:
+        size_in_percentage: 40
     processors:
       batch: {}
       memory_limiter:
         check_interval: 5s
-        limit_mib: 80
-        spike_limit_mib: 25
+        limit_percentage: 80
+        spike_limit_percentage: 25
       spanmetrics:
         metrics_exporter: prometheus
     receivers:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.1
+    helm.sh/chart: opentelemetry-collector-0.40.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.64.1"
+    app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -22,7 +22,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e5f109652435656a1bb3afa873ce9059b1346a27d66a7c2d6cfd0cca261b20ae
+        checksum/config: 07b5edf1d287a4731a68f8ffcd0fa89ab855ae19f832f972b83f719d535c9dfc
         opentelemetry_community_demo: "true"
         prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
@@ -43,7 +43,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.64.1"
+          image: "otel/opentelemetry-collector-contrib:0.66.0"
           imagePullPolicy: IfNotPresent
           ports:
             - name: jaeger-compact

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/service.yaml
@@ -5,10 +5,10 @@ kind: Service
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.1
+    helm.sh/chart: opentelemetry-collector-0.40.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.64.1"
+    app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm
     component: standalone-collector
 spec:

--- a/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/opentelemetry-collector/serviceaccount.yaml
@@ -5,8 +5,8 @@ kind: ServiceAccount
 metadata:
   name: example-otelcol
   labels:
-    helm.sh/chart: opentelemetry-collector-0.39.1
+    helm.sh/chart: opentelemetry-collector-0.40.2
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: example
-    app.kubernetes.io/version: "0.64.1"
+    app.kubernetes.io/version: "0.66.0"
     app.kubernetes.io/managed-by: Helm

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/clusterrole.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-15.16.1
+    chart: prometheus-17.0.2
     heritage: Helm
   name: example-prometheus-server
 rules:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/clusterrolebinding.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-15.16.1
+    chart: prometheus-17.0.2
     heritage: Helm
   name: example-prometheus-server
 subjects:

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/cm.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/cm.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-15.16.1
+    chart: prometheus-17.0.2
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/deploy.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/deploy.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-15.16.1
+    chart: prometheus-17.0.2
     heritage: Helm
   name: example-prometheus-server
   namespace: default
@@ -24,7 +24,7 @@ spec:
         component: "server"
         app: prometheus
         release: example
-        chart: prometheus-15.16.1
+        chart: prometheus-17.0.2
         heritage: Helm
     spec:
       enableServiceLinks: true

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/pvc.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/pvc.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-15.16.1
+    chart: prometheus-17.0.2
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/service.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/service.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-15.16.1
+    chart: prometheus-17.0.2
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/serviceaccount.yaml
+++ b/charts/opentelemetry-demo/examples/default/rendered/prometheus/server/serviceaccount.yaml
@@ -7,7 +7,7 @@ metadata:
     component: "server"
     app: prometheus
     release: example
-    chart: prometheus-15.16.1
+    chart: prometheus-17.0.2
     heritage: Helm
   name: example-prometheus-server
   namespace: default

--- a/charts/opentelemetry-demo/values.yaml
+++ b/charts/opentelemetry-demo/values.yaml
@@ -613,9 +613,9 @@ prometheus:
       enabled: false
   kubeStateMetrics:
     enabled: false
-  nodeExporter:
+  prometheus-node-exporter:
     enabled: false
-  pushgateway:
+  prometheus-pushgateway:
     enabled: false
 
   server:


### PR DESCRIPTION
This updates Collector, Prometheus, and Grafana sub-chart dependencies.

The Prometheus chart made changes to how they implement the node exporter and push gateway.  Those name updates are reflected in values.yaml.